### PR TITLE
chore: populate v1 docs

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1,0 +1,94 @@
+openapi: 3.1.0
+info:
+  title: Indibills API
+  version: 0.1.0
+servers:
+  - url: https://api.indibills.dev
+paths:
+  /auth/signup:
+    post:
+      summary: Create user
+  /accounts:
+    get:
+      summary: List accounts
+  /transactions:
+    get:
+      summary: List transactions
+    post:
+      summary: Create manual transaction
+      parameters:
+        - name: Idempotency-Key
+          in: header
+          schema:
+            type: string
+  /schedules:
+    get:
+      summary: List schedules
+    post:
+      summary: Create schedule (manual)
+  /schedules/{id}/occurrences:
+    get:
+      summary: List occurrences
+  /schedules/from-transaction:
+    post:
+      summary: Create schedule by labeling an existing transaction
+  /transactions/{id}/link-schedule:
+    post:
+      summary: Link a transaction to a schedule occurrence
+  /runway:
+    get:
+      summary: Get runway summary
+      parameters:
+        - in: query
+          name: optimism
+          schema:
+            type: string
+            enum: [conservative, neutral, optimistic]
+  /buffer/settings:
+    get:
+      summary: Get unexpected-spend buffer settings
+    put:
+      summary: Update unexpected-spend buffer settings
+  /plaid/link/token:
+    post:
+      summary: Create link token
+  /plaid/item/exchange:
+    post:
+      summary: Exchange public_token for access_token
+  /webhooks/plaid:
+    post:
+      summary: Plaid webhook receiver
+components:
+  schemas:
+    Money:
+      type: object
+      properties:
+        amount_cents:
+          type: integer
+        currency:
+          type: string
+          enum: [USD]
+    Account:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        type:
+          type: string
+          enum: [asset, liability]
+        balance:
+          $ref: '#/components/schemas/Money'
+    RunwaySummary:
+      type: object
+      properties:
+        days:
+          type: integer
+        zero_date:
+          type: string
+          format: date
+        assumptions:
+          type: array
+          items:
+            type: string

--- a/docs/00-brief.md
+++ b/docs/00-brief.md
@@ -1,0 +1,31 @@
+# Indibills – One-Page Product Brief
+
+## Problem
+Gig and freelance workers struggle to see how long they can survive on current cash given irregular income and upcoming expenses (including surprise spending).
+
+## Audience
+US-based gig drivers (Uber, Lyft, DoorDash) and freelancers (contract or project-based) who are comfortable linking bank accounts.
+
+## Core Value
+A clear **days-of-runway** number paired with a deterministic cash-flow simulation that updates as money moves.
+
+## Key Constraints
+- Security and PII protection come first: encrypted tokens, minimal data retention, strict logging.
+- v1 integrates Plaid for banks and offers manual CSV import as a fallback.
+- Platform OAuth connectors and mileage tracking are out of scope for v1.
+
+## v1 Out-of-Scope (Future)
+- Automated tax estimation.
+- Invoice generation.
+- ML forecasting.
+
+## Success Metrics (first 60 days)
+- Time to first value (TTFV) is **less than 10 minutes** from signup to viewing a runway.
+- Daily/weekly active users reach **≥40%** of signups in week 1.
+- Reconciliation tests achieve **≥90%** correctness with zero PII in logs.
+
+## Open Questions
+- Which additional gig platforms should be prioritized for future connectors?
+- Are users satisfied with the conservative/neutral/optimistic runway modes?
+- What manual-import enhancements are needed for non-Plaid banks?
+

--- a/docs/architecture/adr/0001-ledger-model.md
+++ b/docs/architecture/adr/0001-ledger-model.md
@@ -1,0 +1,20 @@
+# ADR 0001: Ledger Model
+
+## Context
+Transactions must be recorded with accuracy and traceability. A traditional double-entry ledger ensures every movement of money balances and provides an audit trail.
+
+## Decision
+Adopt a double-entry ledger using integer cents. Each journal entry **MUST** contain at least two postings that sum to zero. Corrections are done with reversing entries; deletions are disallowed.
+
+## Consequences
+- Guarantees accounting integrity and supports reconciliation.
+- Requires developers to model transactions explicitly and handle reversing entries.
+- Enables future reporting and audit features without schema changes.
+
+## Alternatives
+- Single-entry ledger with mutable balances (rejected due to reconciliation difficulty).
+- Floating-point money representation (rejected for precision issues).
+
+## Status
+Accepted – Sept 2025.
+

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -1,0 +1,35 @@
+# System Architecture Overview
+
+## Context
+Indibills is a personal finance web app for gig and freelance workers. It exposes a FastAPI backend with a Next.js (React + TypeScript) frontend. The backend integrates Plaid, Postgres, Redis, a job runner, and object storage for CSV imports.
+
+## Components
+- **Web Client**: Next.js app communicating via JSON over HTTPS.
+- **API**: FastAPI application providing REST endpoints and Webhooks.
+- **Worker**: Background processor (Dramatiq or Celery) for sync and reconciliation jobs.
+- **Databases**:
+  - Postgres for relational data and ledger entries.
+  - Redis for caching and job queues.
+  - Object storage for uploaded CSV files.
+- **Plaid**: Third-party bank aggregator.
+
+## Trust Boundaries
+```
+[Browser] <--HTTPS--> [API] <--TLS--> [Plaid]
+                      |
+                      +-- [Postgres]
+                      +-- [Redis]
+                      +-- [Object Storage]
+```
+Secrets stay server-side. No PII in logs.
+
+## Data Stores
+- Postgres: user accounts, ledger, schedules, audit logs.
+- Redis: session cache, job queue.
+- Object storage: raw CSV imports.
+
+## Runtime Limits
+- 30s maximum request time.
+- Job retries with exponential backoff.
+- Plaid rate limits respected; API throttles per IP/user.
+

--- a/docs/domain/ledger-model.md
+++ b/docs/domain/ledger-model.md
@@ -1,0 +1,41 @@
+# Ledger Model
+
+## Entities
+- **Account**: `id`, `user_id`, `name`, `type {asset|liability}`, `institution`, `last_sync_at`.
+- **JournalEntry**: `id`, `user_id`, `occurred_at`, `source {csv|plaid|manual}`, `external_id`.
+- **Posting**: `id`, `entry_id`, `account_id`, `amount_cents` (signed), `currency`, `memo`.
+- **Transaction (view)**: joins entry with normalized merchant/category and plaid ids.
+- **Schedule**: recurring or one-time expense/income definitions.
+- **ScheduleOccurrence**: specific due instances with `status {pending|partial|satisfied}` and optional link to ledger entry.
+- **Signature**: recognition hints for matching transactions to schedules.
+- **Match**: links occurrences to entries and tracks partial/full amounts.
+
+## Invariants
+- Sum of `amount_cents` in postings for a journal entry **MUST** equal zero.
+- Money is stored as integer cents in USD for v1.
+- Deletions are soft or handled via reversing entries.
+
+## Posting Examples
+```
+Entry: Paycheck
+  Debit  Asset:Checking  +100000
+  Credit Income:Wages   -100000
+```
+```
+Entry: Rent
+  Debit  Expense:Rent    +120000
+  Credit Asset:Checking -120000
+```
+
+## Reconciliation Rules
+- Schedule occurrences **MUST** be marked satisfied when linked to postings totaling the expected amount.
+- Partial matches **MAY** leave the occurrence in `partial` state until fully satisfied.
+
+## Reversing Entries
+- To correct mistakes, create a new journal entry that negates prior postings.
+- Audit logs **MUST** record original and reversing entry references.
+
+## Signatures
+- Stored per schedule to aid auto-detection: merchant, ACH descriptor, MCC, typical amount band, cadence window, account filter.
+- False positives **MUST** be down-weighted when dismissed by users.
+

--- a/docs/domain/money.md
+++ b/docs/domain/money.md
@@ -1,0 +1,22 @@
+# Money Value Object
+
+## Representation
+- Amount stored as signed 64-bit integer representing cents.
+- Currency stored as ISO code (`USD` in v1).
+- No floating point math; arithmetic uses integer operations.
+
+## Operations
+- Addition/subtraction **MUST** check currency equality.
+- Formatting to user locale **SHOULD** occur at UI layer.
+- Conversions between currencies are out of scope for v1.
+
+## Invariants
+- Overflow **MUST NOT** occur; guard with bounds checks.
+- Zero amount represents absence of value but retains currency.
+
+## Examples
+```
+Money(2500, "USD")  # $25.00
+Money(-120000, "USD")  # -$1,200.00
+```
+

--- a/docs/specs/v1-functional-spec.md
+++ b/docs/specs/v1-functional-spec.md
@@ -1,0 +1,166 @@
+# v1 Functional Spec
+
+Use **RFC-2119** keywords. Each feature includes purpose, states, edge cases, and acceptance criteria.
+
+## 1. Authentication & Onboarding
+**Purpose**
+Provide secure signup/login and guide new users through initial setup.
+
+**Requirements**
+- Users **MUST** sign up with email and password.
+- After first login, a 3-step checklist **MUST** prompt users to: link accounts (Plaid or CSV), add/identify expenses & income, and view runway.
+
+**States**
+1. `new` – no checklist items complete.
+2. `partial` – at least one item complete.
+3. `ready` – link/import and ≥1 expense/income identified.
+
+**Edge Cases**
+- User closes browser mid-checklist; progress **MUST** persist.
+- Duplicate email signup **MUST** be rejected.
+
+**Acceptance**
+- **Given** a new user
+- **When** they link a bank or import a CSV and create or identify at least one expense
+- **Then** they **MUST** see a runway number.
+
+## 2. Accounts & Balances
+**Purpose**
+Represent financial accounts and derive balances from ledger entries.
+
+**Requirements**
+- Accounts **MUST** have type `asset` or `liability`.
+- Balances **MUST** derive from immutable ledger postings; no mutable running totals.
+
+**States**
+- `active` – synced or manually managed.
+- `disabled` – user removed or deauthorized; historical data retained.
+
+**Edge Cases**
+- Negative balances on liabilities **MUST** display with sign.
+- Unknown account types from Plaid **MUST** map to default `asset` until user edits.
+
+**Acceptance**
+- **Given** an account with postings totaling $200 debit and $50 credit
+- **When** balance is computed
+- **Then** resulting balance **MUST** be $150.
+
+## 3. Transactions & Ledger
+**Purpose**
+Capture all money movement with double-entry journal entries.
+
+**Requirements**
+- Imported or manual transactions **MUST** map to journal entries with ≥2 postings summing to zero.
+- Transactions **MUST NOT** be deleted; corrections are reversing entries.
+
+**States**
+- `pending` – imported but not reviewed.
+- `cleared` – verified and reconciled.
+
+**Edge Cases**
+- Duplicate imports **MUST** be idempotent.
+- Partial reversals **SHOULD** allow correcting amount while retaining audit history.
+
+**Acceptance**
+- **Given** a transaction mistakenly categorized
+- **When** a reversing entry is posted
+- **Then** the ledger **MUST** net to zero with an audit trail.
+
+## 4. Schedules (Expenses & Expected Income)
+**Purpose**
+Track recurring and one-time cash flows.
+
+**Requirements**
+- Users **MUST** create schedules with due date or RRULE, amount, and category.
+- The system **SHOULD** support flexing to nearest business day.
+
+**States**
+- `pending` – upcoming occurrence.
+- `partial` – linked but not fully satisfied.
+- `satisfied` – amount fully matched to transactions.
+
+**Edge Cases**
+- Editing amount after occurrences exist **MUST** only affect future ones.
+- Skipped occurrences **MAY** be manually marked satisfied.
+
+### 4.1 Recurrence Recognition & Linking
+**Expenses**
+1. **Label from Transaction** – From a synced transaction, user marks it recurring. The system **MUST** create a schedule and store a recognition signature (merchant, descriptor, amount band, account, cadence).
+2. **Manual First, Link Later** – User adds a manual schedule and later links it when the transaction arrives. Linking **MUST** satisfy the occurrence and refine the signature.
+
+**Income**
+The same flows **MUST** exist for income items. Labeling income **MUST** create a schedule with income kind and recognition signature.
+
+**Auto-Detection**
+On each sync, the system **SHOULD** match incoming transactions to known signatures and **SHOULD** propose confirmations. False positives **MUST** be dismissible and down-weight the signature.
+
+**Acceptance Examples**
+- **Given** a DoorDash deposit with descriptor "DOORDASH*PAY" every week ±2 days and amount within ±10%
+- **When** labeled recurring
+- **Then** future matches **SHOULD** auto-link.
+- **Given** a manual "Rent $1200 due on 1st (flex to business day)"
+- **When** a $1200 ±$5 transaction posts within 3 days of due date
+- **Then** it **SHOULD** be matched and marked satisfied.
+
+## 5. Runway Engine
+**Purpose**
+Forecast days of cash runway.
+
+**Requirements**
+- Engine **MUST** simulate daily cash flows until balance < 0.
+- Inputs include current balances, schedules, expected income, known transfers, and unexpected-spend buffer.
+- Outputs **MUST** include days of runway, projected zero date, and assumptions.
+- A mode toggle **MAY** adjust expected-income inclusion (0%/50%/100%) and buffer intensity.
+
+**Unexpected-Spend Buffer**
+- System **MUST** estimate non-scheduled spend using a rolling average of prior unlinked debit spend.
+- Supported settings: `buffer_mode` ∈ {off, avg30, avg90, manual}; `buffer_floor_cents`; `exclude_categories`.
+- Users **MUST** be able to mark transactions as excluded from buffer calculations.
+
+**Examples**
+- $1,000 balance with $50/day scheduled burn and $15/day buffer → runway **MUST** be 15 days.
+- $600 income expected day 10 with neutral mode (50%) **SHOULD** extend runway proportionally.
+
+**Edge Cases**
+- Negative starting balance **MUST** yield zero days.
+- Buffer mode `off` **MUST** omit buffer from simulation.
+
+**Acceptance**
+- **Given** a user with configured schedules and buffer
+- **When** they request a runway summary
+- **Then** API **MUST** return days, zero date, and assumptions.
+
+## 6. Reconciliation
+**Purpose**
+Match transactions to schedule occurrences.
+
+**Requirements**
+- System **SHOULD** auto-match transactions via signature/date/amount.
+- Users **MUST** be able to relink or unlink matches.
+- Occurrences **MUST** be marked satisfied once matched; partial matches allowed.
+
+**Edge Cases**
+- Multiple transactions satisfying one occurrence **MUST** mark partial then satisfied.
+- Over-matching **MUST** be reversible.
+
+**Acceptance**
+- **Given** a schedule occurrence and matching transaction
+- **When** auto-matched
+- **Then** status **MUST** change to satisfied.
+
+## 7. Audit & Safety
+**Purpose**
+Ensure traceability and safe retries.
+
+**Requirements**
+- All mutation endpoints **MUST** accept an `Idempotency-Key` header.
+- Every mutation **MUST** emit a redacted audit log event.
+
+**Edge Cases**
+- Replayed requests with same key **MUST** return prior result.
+
+**Acceptance**
+- **Given** a valid mutation request with `Idempotency-Key`
+- **When** the request is repeated
+- **Then** the system **MUST** return the same response and log once.
+

--- a/ops/runbooks.md
+++ b/ops/runbooks.md
@@ -1,0 +1,25 @@
+# Ops Runbooks
+
+## Plaid Outage
+1. Confirm outage via Plaid status page.
+2. Pause sync jobs; queue retries.
+3. Communicate status to users via banner.
+4. Resume jobs once Plaid reports recovery; monitor for backlog clearing.
+
+## Webhook Replay
+1. Verify webhook signature.
+2. If replay, ensure `Idempotency-Key` prevents duplicate processing.
+3. Log replay event with correlation ID.
+4. Reprocess if previous attempt failed.
+
+## CSV Import Errors
+1. Validate CSV schema; reject rows with missing required fields.
+2. Return aggregated error report to user.
+3. Allow user to fix and re-upload; prior valid entries **MUST NOT** duplicate.
+
+## Data Redaction Request
+1. Authenticate requester.
+2. Queue redaction job referencing user ID.
+3. Remove personal data from logs, storage, and database per policy.
+4. Confirm completion to requester within SLA.
+

--- a/security/SECURITY.md
+++ b/security/SECURITY.md
@@ -1,0 +1,18 @@
+# Security Policy
+
+## Reporting
+Report vulnerabilities to security@indibills.dev. We acknowledge reports within 2 business days and aim to resolve critical issues within 7 days.
+
+## Dependency Policy
+- Dependencies **MUST** come from the approved allowlist.
+- Automated tooling **SHOULD** check for known CVEs weekly.
+
+## Code Scanning
+- CI **MUST** run static analysis and dependency audits.
+- Secrets scanners **MUST** block commits containing credentials.
+
+## Secrets Handling
+- Secrets **MUST** be stored in the secret manager; never committed to the repo.
+- Access tokens (e.g., Plaid) **MUST** be encrypted at rest and rotated periodically.
+- Logs **MUST NOT** contain PII or secret values.
+

--- a/security/threat-model.md
+++ b/security/threat-model.md
@@ -1,0 +1,11 @@
+# Threat Model
+
+| STRIDE Category | Threat Example | Mitigation | Residual Risk | Test Hook |
+| --- | --- | --- | --- | --- |
+| Spoofing | Impersonated user sessions | Strong auth, secure cookies | Low if passwords reused elsewhere | Session hijack test cases |
+| Tampering | Ledger modification | Idempotency keys, immutable postings | None | Property tests on ledger |
+| Repudiation | User denies action | Audit events with redaction | Low | Verify audit log entries |
+| Information Disclosure | PII leakage in logs | Structured logging with redaction, TLS | Medium via 3rd-party breach | Log scanning in CI |
+| Denial of Service | Plaid webhook flood | Rate limiting, backpressure | Medium | Load tests for webhook endpoints |
+| Elevation of Privilege | Access to other users' data | RBAC (future), strict token scoping | Medium until multi-user | Integration tests on auth checks |
+


### PR DESCRIPTION
## Summary
- fill product brief, architecture overview, and ledger ADR
- add functional spec, security policy, threat model, and runbooks
- sketch OpenAPI schema for core endpoints

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c4b8e29edc832590d1c79f53b9e8dd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Published an OpenAPI 3.1 specification for the Indibills API, covering signup, accounts, transactions (idempotent creates), schedules (manual/from-transaction/linking), runway summary (optimism modes), buffer settings (get/update), Plaid link/exchange, and a webhook receiver. Includes high-level data schemas and enums (e.g., USD currency, optimism levels).

- Documentation
  - Added product brief, architecture overview, ADR on ledger model, domain docs (ledger, money), v1 functional spec, ops runbooks (Plaid outage, webhook replay, CSV errors, data redaction), security policy, and a STRIDE-based threat model.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->