### PR TITLE
Fixed Pruning Behavior on Docker Migration Worker, Added Makefile

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,4 +7,6 @@ POSTGRES_PASSWORD=super_secret_root_password
 APP_RUNTIME_PASSWORD=runtime_password
 APP_WORKER_PASSWORD=worker_password
 APP_ADMIN_PASSWORD=admin_password
+# Passwords with symbols @, :, /, ?, #, %, [, and ] need to be percent encoded for connection strings
+APP_ADMIN_PASSWORD_URLENC=admin_password
 AUDITOR_PASSWORD=auditor_password

--- a/.env.example
+++ b/.env.example
@@ -1,12 +1,14 @@
-# PostgreSQL Root Password (used by Docker image)
-POSTGRES_DB=intellibills
-POSTGRES_USER=postgres
-POSTGRES_PASSWORD=super_secret_root_password
-
 # Intellibills Application Roles
-APP_RUNTIME_PASSWORD=runtime_password
-APP_WORKER_PASSWORD=worker_password
 APP_ADMIN_PASSWORD=admin_password
 # Passwords with symbols @, :, /, ?, #, %, [, and ] need to be percent encoded for connection strings
 APP_ADMIN_PASSWORD_URLENC=admin_password
+APP_RUNTIME_PASSWORD=runtime_password
+APP_WORKER_PASSWORD=worker_password
 AUDITOR_PASSWORD=auditor_password
+
+# PostgreSQL Root Password (used by Docker image)
+POSTGRES_DB=intellibills
+POSTGRES_PASSWORD=super_secret_root_password
+POSTGRES_USER=postgres
+
+

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,19 @@
+.PHONY: db-up db-down db-clean
+
+
+# Starts the database and runs the ephemeral migration container
+
+db-up:
+	docker-compose up -d db
+	docker-compose run --rm migrate
+
+
+# Stops the database safely
+db-down:
+	docker-compose down
+
+# Nukes the database and the volume (perfect for resetting your test state)
+db-clean:
+
+	docker-compose down -v
+	docker image prune -f

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,12 @@
-.PHONY: db-up db-down db-clean
+.PHONY: all clean test db-up db-down db-clean
+all: db-up
 
+clean: db-clean
+
+test: 
+		@echo "Test suite not yet implemented"
 
 # Starts the database and runs the ephemeral migration container
-
 db-up:
 	docker-compose up -d db
 	docker-compose run --rm migrate
@@ -14,6 +18,4 @@ db-down:
 
 # Nukes the database and the volume (perfect for resetting your test state)
 db-clean:
-
-	docker-compose down -v
-	docker image prune -f
+	docker-compose down -v --rmi local

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
       - ./db/migrations:/migrations
     command:
       - -path=/migrations
-      - -database=postgres://app_admin:${APP_ADMIN_PASSWORD}@db:5432/${POSTGRES_DB:-intellibills}?sslmode=disable
+      - -database=postgres://app_admin:${APP_ADMIN_PASSWORD_URLENC}@db:5432/${POSTGRES_DB:-intellibills}?sslmode=disable
       - up
     depends_on:
       db:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,14 +22,14 @@ services:
       retries: 5
   migrate:
     image: migrate/migrate
-    container_name: intellibills_migrate
+    profiles: ["tools"]
     env_file:
       - .env
     volumes:
       - ./db/migrations:/migrations
     command:
       - -path=/migrations
-      - -database=postgres://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB:-intellibills}?sslmode=disable
+      - -database=postgres://app_admin:${APP_ADMIN_PASSWORD}@db:5432/${POSTGRES_DB:-intellibills}?sslmode=disable
       - up
     depends_on:
       db:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added Makefile targets to manage local build/test workflows and database lifecycle (start, stop, clean); includes a placeholder test target.
  * Updated migration tooling to run via a tooling profile and use a dedicated database admin credential supplied through environment variables.
* **Documentation**
  * Added guidance for percent-encoding passwords in connection strings and an example admin password variable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->